### PR TITLE
Add command line specification of model reload and learning rate schedule

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -450,7 +450,7 @@ class DiskDataset(Dataset):
       (self.tasks,
        self.metadata_df) = load_from_disk(self._get_metadata_filename())
     else:
-      raise ValueError("No metadata found on disk.")
+      raise ValueError("No metadata file found on disk: %s" % self._get_metadata_filename())
 
   @staticmethod
   def create_dataset(shard_generator,
@@ -664,7 +664,7 @@ class DiskDataset(Dataset):
   def ani_iterbatches(self, deterministic=False):
     """ Get an object that iterates over minibatches from the dataset. It is guaranteed
     that the number of batches returned is math.ceil(len(dataset)/batch_size).
-    
+
     Each minibatch is returned as a tuple of four numpy arrays: (X, y, w, ids).
 
 
@@ -689,7 +689,7 @@ class DiskDataset(Dataset):
 
     """
     def iterate(dataset):
-    
+
 
       it_start_time = time.time()
 
@@ -740,7 +740,7 @@ class DiskDataset(Dataset):
                   pad_batches=False):
     """ Get an object that iterates over minibatches from the dataset. It is guaranteed
     that the number of batches returned is math.ceil(len(dataset)/batch_size).
-    
+
     Each minibatch is returned as a tuple of four numpy arrays: (X, y, w, ids).
 
 
@@ -765,7 +765,7 @@ class DiskDataset(Dataset):
 
     """
     def iterate(dataset, batch_size):
-    
+
       it_start_time = time.time()
 
       num_shards = dataset.get_number_shards()

--- a/examples/roitberg/roitberg.py
+++ b/examples/roitberg/roitberg.py
@@ -345,6 +345,7 @@ if __name__ == "__main__":
 
   max_atoms = args.max_atoms
   batch_size = args.batch_size
+  train_batch_size = args.featurization_batch_size * 3
   layer_structures = [256, 128, 64, 1]
   atom_number_cases = [1, 6, 7, 8]
 
@@ -353,9 +354,6 @@ if __name__ == "__main__":
       dc.metrics.Metric(dc.metrics.mean_absolute_error, mode="regression"),
       dc.metrics.Metric(dc.metrics.pearson_r2_score, mode="regression")
   ]
-
-  feat_batch_size = 384
-  train_batch_size = feat_batch_size*3
 
   # switch for datasets and models
   if path_not_empty(args.valid_dir) and \


### PR DESCRIPTION
Adds an option to force model reload, and to specify the starting learning rate and the learning rate factor (i.e. change the default schedule of lr /= 10).

Also fixed an error message to be more informative and moved argument sanity checks into arg parsing method.